### PR TITLE
Fix dockerignore formatting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-node_modules;
-npm - debug.log;
-Dockerfile.dockerignore;
-build.bat;
+node_modules
+npm-debug.log
+Dockerfile.dockerignore
+build.bat


### PR DESCRIPTION
## Summary
- clean up `.dockerignore` entries

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68467d5647dc8330bfb811a429af785d